### PR TITLE
Cache HTTP mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set( CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 
 find_package( Xrootd REQUIRED )
 find_package( Lcmaps REQUIRED )
+find_package( Voms   REQUIRED )
 
 if( CMAKE_COMPILER_IS_GNUCXX )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -DLCMAPS_GSI_MODE=1" )
@@ -15,12 +16,10 @@ if( CMAKE_COMPILER_IS_GNUCC )
   set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -DLCMAPS_GSI_MODE=1" )
 endif()
 
-include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}"
-"${LCMAPS_INCLUDES}" )
+include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" "${LCMAPS_INCLUDES}" "${VOMS_INCLUDES}")
 
 add_library(XrdLcmaps MODULE src/XrdLcmaps.cc src/XrdHttpLcmaps.cc src/XrdLcmapsConfig.cc src/XrdLcmapsKey.cc)
-target_link_libraries(XrdLcmaps ${XROOTD_SECGSI} ${XROOTD_CRYPTOSSL}
-${LCMAPS_LIB} ${DL_LIB})
+target_link_libraries(XrdLcmaps ${XROOTD_SECGSI} ${XROOTD_CRYPTOSSL} ${LCMAPS_LIB} ${DL_LIB} ${VOMS_LIB})
 
 if (NOT DEFINED CMAKE_INSTALL_LIBDIR)
   SET(CMAKE_INSTALL_LIBDIR "lib")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}"
 "${LCMAPS_INCLUDES}" )
 
-add_library(XrdLcmaps MODULE src/XrdLcmaps.cc src/XrdHttpLcmaps.cc src/XrdLcmapsConfig.cc)
+add_library(XrdLcmaps MODULE src/XrdLcmaps.cc src/XrdHttpLcmaps.cc src/XrdLcmapsConfig.cc src/XrdLcmapsKey.cc)
 target_link_libraries(XrdLcmaps ${XROOTD_SECGSI} ${XROOTD_CRYPTOSSL}
 ${LCMAPS_LIB} ${DL_LIB})
 

--- a/cmake/FindVoms.cmake
+++ b/cmake/FindVoms.cmake
@@ -1,0 +1,20 @@
+
+FIND_PATH(VOMS_INCLUDES voms/voms_apic.h
+  HINTS
+  ${VOMS_DIR}
+  $ENV{VOMS_DIR}
+  /usr
+  PATH_SUFFIXES include
+)
+
+FIND_LIBRARY(VOMS_LIB vomsapi
+  HINTS
+  ${VOMS_DIR}
+  $ENV{VOMS_DIR}
+  /usr
+  PATH_SUFFIXES lib
+)
+
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Voms DEFAULT_MSG VOMS_LIB VOMS_INCLUDES)
+

--- a/spec/xrootd-lcmaps.spec
+++ b/spec/xrootd-lcmaps.spec
@@ -15,6 +15,7 @@ BuildRequires: xrootd-libs-devel
 BuildRequires: lcmaps-interface
 BuildRequires: lcmaps
 BuildRequires: cmake
+BuildRequires: voms-devel
 Requires: xrootd-server >= 1:3.2
 
 %description

--- a/src/XrdHttpLcmaps.cc
+++ b/src/XrdHttpLcmaps.cc
@@ -87,11 +87,6 @@ class XrdMappingCache
 {
 public:
 
-    XrdMappingCache()
-      : m_last_clean(monotonic_time())
-    {
-    }
-
 
     ~XrdMappingCache()
     {
@@ -151,13 +146,21 @@ public:
     }
 
 
-    static XrdMappingCache &GetInstance() {return m_cache;}
+    static XrdMappingCache &GetInstance()
+    {
+        return m_cache;
+    }
 
 private:
 
     // No copying...
     XrdMappingCache& operator=(XrdMappingCache const&);
     XrdMappingCache(XrdMappingCache const&);
+
+    XrdMappingCache()
+      : m_last_clean(monotonic_time())
+    {
+    }
 
     /**
      * MUST CALL LOCKED
@@ -186,7 +189,7 @@ private:
     static XrdMappingCache m_cache;
 };
 
-XrdMappingCache::XrdMappingCache m_cache;
+XrdMappingCache XrdMappingCache::m_cache;
 
 
 class XrdHttpLcmaps : public XrdHttpSecXtractor

--- a/src/XrdLcmaps.cc
+++ b/src/XrdLcmaps.cc
@@ -13,6 +13,7 @@
 /* ************************************************************************** */
 
 #include "XrdLcmapsConfig.hh"
+#include "XrdLcmapsKey.hh"
 
 #include <iostream>
 #include <stdio.h>
@@ -42,7 +43,6 @@ XrdSysMutex mutex;
 
 int XrdSecgsiAuthzInit(const char *cfg);
 int XrdSecgsiAuthzFun(XrdSecEntity &entity);
-int XrdSecgsiAuthzKey(XrdSecEntity &entity, char **key);
 }
 
 #define policy_count 1

--- a/src/XrdLcmapsKey.cc
+++ b/src/XrdLcmapsKey.cc
@@ -1,0 +1,46 @@
+
+#include <string>
+#include <sstream>
+
+#include <voms/voms_apic.h>
+
+#include <openssl/crypto.h>
+
+/**
+ * Build a hash key from the DN and VOMS info.
+ */
+std::string
+GetKey(X509 *cert, STACK_OF(X509*) chain)
+{
+    std::stringstream key;
+    // Start with the DN
+    char *dn = X509_NAME_oneline(X509_get_subject_name(cert), NULL, 0);
+    key << dn << "::";
+    free(dn);
+
+    // Parse VOMS data and append that.
+    struct vomsdata *voms_ptr = VOMS_Init(NULL, NULL);
+    int errcode = 0;
+    if (VOMS_Retrieve(cert, chain, RECURSE_CHAIN, voms_ptr, &errcode))
+    {
+        return key.str();
+    }
+
+    for (int idx = 0; voms_ptr->data[idx] != NULL; idx++)
+    {
+        struct voms *it = voms_ptr->data[idx];
+        if (!it->voname) {continue;}
+        key << it->voname << ":";
+        for (int idx2 = 0; it->std[idx2] != NULL; idx2++)
+        {
+            struct data *it2 = it->std[idx2];
+            if (!it2->group) {continue;}
+            key << it2->group;
+            if (it2->role) {key << "Role=" << it2->role;}
+            key << ",";
+        }
+        key << "::";
+    }
+    return key.str();
+}
+

--- a/src/XrdLcmapsKey.hh
+++ b/src/XrdLcmapsKey.hh
@@ -1,0 +1,16 @@
+#ifndef __XRD_LCMAPS_KEY_HH_
+#define __XRD_LCMAPS_KEY_HH_
+
+#include <string>
+
+#include <openssl/crypto.h>
+
+#include <XrdSec/XrdSecEntity.hh>
+
+extern "C" {
+int XrdSecgsiAuthzKey(XrdSecEntity &entity, char **key);
+}
+
+std::string GetKey(X509 *cert, STACK_OF(X509*) chain);
+
+#endif


### PR DESCRIPTION
This causes the LCMAPS lookup to be cached for HTTP-based mappings.

The caching for the Xrootd protocol is built into the `XrdSec` object itself; we have to implement our own for HTTP.